### PR TITLE
test-requirements.txt + workaround nodepool dep.

### DIFF
--- a/osci/nodepool_manager.py
+++ b/osci/nodepool_manager.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import Queue
-from nodepool import nodedb, nodepool
 from osci.config import Configuration
 
 
@@ -38,6 +37,9 @@ class NodePool():
     log = logging.getLogger('citrix.nodepool')
 
     def __init__(self, image):
+        from nodepool import nodedb, nodepool
+        self.nodedb = nodedb
+
         self.pool = nodepool.NodePool(Configuration().NODEPOOL_CONFIG)
         config = self.pool.loadConfig()
         self.pool.reconfigureDatabase(config)
@@ -54,10 +56,10 @@ class NodePool():
             for node in session.getNodes():
                 if node.image_name != self.image:
                     continue
-                if node.state != nodedb.READY:
+                if node.state != self.nodedb.READY:
                     continue
                 # Allocate this node
-                node.state = nodedb.HOLD
+                node.state = self.nodedb.HOLD
                 return node.id, node.ip
         return None, None
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+nose
+mock
+pygerrit
+paramiko
+mysql-python


### PR DESCRIPTION
Added a proper test-requirements.txt to set up all the test dependencies
in one go. To avoid the need for the nodepool, the import has been moved
to the inside of the class.
