### PR TITLE
Made delete thread even less dependent on the current state / state chan...

### DIFF
--- a/osci/nodepool_manager.py
+++ b/osci/nodepool_manager.py
@@ -35,6 +35,15 @@ class NodePool():
                 return node.id, node.ip
         return None, None
 
+    def getHeldNodes(self):
+        heldNodes = set()
+        with self.getSession() as session:
+            for node in session.getNodes():
+                if node.state != self.nodedb.HOLD:
+                    continue
+                heldNodes.add(node.id)
+        return heldNodes
+
     def deleteNode(self, node_id):
         if not node_id:
             return


### PR DESCRIPTION
...ges.

Nodes were somehow getting lost, with osci-manage --list showing the node
as not in use, but it was still held by nodepool.

With this change we now use nodepool to list the nodes that we can delete
