### PR TITLE
Rely on upstart's respawn when gerrit stream dies

### DIFF
--- a/osci/commands.py
+++ b/osci/commands.py
@@ -171,18 +171,14 @@ class WatchGerrit(object):
                 raise GerritEventError('Event [%s] matched error filter'%event)
             event = self.get_event()
 
-    def _retry_connect(self):
-        return True
-
     def __call__(self):
-        while self._retry_connect():
-            self.gerrit_client.connect()
-            self.last_event = time_services.now()
-            try:
-                while self.event_seen_recently():
-                    self.do_event_handling()
-                    self.sleep()
-                log.info("Dropped out of event_seen_recently loop")
-            except GerritEventError, e:
-                log.exception(e)
-            self.gerrit_client.disconnect()
+        self.gerrit_client.connect()
+        self.last_event = time_services.now()
+        try:
+            while self.event_seen_recently():
+                self.do_event_handling()
+                self.sleep()
+            log.info("No events seen in %s seconds" % self.recent_event_time)
+        except GerritEventError as e:
+            log.exception(e)
+        self.gerrit_client.disconnect()

--- a/osci/tests/test_commands.py
+++ b/osci/tests/test_commands.py
@@ -168,11 +168,8 @@ class TestWatchGerritMainLoop(unittest.TestCase):
             mock.patch.object(cmd, 'sleep'),
             mock.patch.object(cmd, 'do_event_handling'),
             mock.patch.object(cmd, 'event_seen_recently'),
-            mock.patch.object(cmd, '_retry_connect'),
             ]
         [patcher.start() for patcher in self.patchers]
-        cmd._retry_connect = mock.Mock()
-        cmd._retry_connect.side_effect = [True, False]
 
     def test_call_connects(self):
         cmd = self.cmd
@@ -188,26 +185,6 @@ class TestWatchGerritMainLoop(unittest.TestCase):
         cmd.event_seen_recently.side_effect = [True, False]
         cmd()
         cmd.do_event_handling.assert_called_once_with()
-
-    def test_call_reconnects(self):
-        cmd = self.cmd
-        cmd.event_seen_recently.return_value = False
-        cmd._retry_connect.side_effect = [True, True, False]
-        cmd()
-        self.assertEquals(2,
-                          len(cmd.gerrit_client.fake_connect_calls))
-        self.assertEquals(2,
-                          len(cmd.gerrit_client.fake_disconnect_calls))
-
-    def test_call_reconnects_error_event(self):
-        cmd = self.cmd
-        cmd.do_event_handling.side_effect = commands.GerritEventError
-        cmd._retry_connect.side_effect = [True, True, False]
-        cmd()
-        self.assertEquals(2,
-                          len(cmd.gerrit_client.fake_connect_calls))
-        self.assertEquals(2,
-                          len(cmd.gerrit_client.fake_disconnect_calls))
 
     def tearDown(self):
         [patcher.stop() for patcher in self.patchers]


### PR DESCRIPTION
One of the failure modes is paramiko's SSH client dying.
Trying to work around this while ensuring we don't leak resources
is quite hard; and upstart should be providing the protection
we need against the stream dying already.

Therefore always abort on gerrit stream errors and let upstart's
respawn re-start the process
