### PR TITLE
Preserve a few of the failed nodes for investigation

### DIFF
--- a/osci/config.py
+++ b/osci/config.py
@@ -23,6 +23,8 @@ class Configuration(object):
         'GERRIT_PORT': '29418',
         'MAX_RUNNING_TIME': str(3*3600+15*60), # 3 hours and 15 minutes
         'DATABASE_URL': 'mysql://root:@127.0.0.1/openstack_ci',
+        'KEEP_FAILED': '3',
+        'KEEP_FAILED_TIMEOUT': str(6*3600),
         'NODEPOOL_CONFIG': '/etc/nodepool/nodepool.yaml',
         'NODEPOOL_IMAGE': 'XSDSVM',
         'NODE_USERNAME': 'jenkins',

--- a/osci/tests/test_config.py
+++ b/osci/tests/test_config.py
@@ -43,3 +43,10 @@ class TestConfig(unittest.TestCase):
         mock_conf_file.return_value = 'POLL=10'
         self.conf.reread()
         self.assertEqual(self.conf.get_int('POLL'), 10)
+
+    @mock.patch.object(config.Configuration, '_conf_file_contents')
+    def test_config_multiple(self, mock_conf_file):
+        mock_conf_file.return_value = 'POLL=10\nRUN_TESTS=False'
+        self.conf.reread()
+        self.assertEqual(self.conf.POLL, '10')
+        self.assertEqual(self.conf.RUN_TESTS, 'False')


### PR DESCRIPTION
The most recent <KEEP_FAILED> nodes will be preserved as long as they
are not older than <KEEP_FAILED_TIMEOUT>
